### PR TITLE
[Launch,Models] Add collision bitmask argument option.

### DIFF
--- a/launch/kopterworx.launch
+++ b/launch/kopterworx.launch
@@ -22,6 +22,8 @@
 
   <!-- Magnet properties - requires storm_gazebo_ros_magnet-->
   <arg name="enable_magnet"   default="false" />
+  <!-- Collision bitmask - by default collide with everything -->
+  <arg name="collision_bitmask" default="-1" />
 
   <include file="$(find ardupilot_gazebo)/launch/empty_world.launch">
     <arg name="paused"          value="false" />
@@ -43,6 +45,7 @@
 		fdm_port_out:=$(arg fdm_port_out)
 		max_range:=$(arg max_range)
     laser_count:=$(arg laser_count)
+    collision_bitmask:=$(arg collision_bitmask)
 	  "
 	/>
 

--- a/launch/spawn_kopterworx.launch
+++ b/launch/spawn_kopterworx.launch
@@ -11,6 +11,9 @@
 	<arg name="model" value="$(find ardupilot_gazebo)/models/kopterworx/urdf/kopterworx.urdf.xacro" />
 	<arg name="fdm_port_in" default="9012"/>
 	<arg name="fdm_port_out" default="9013"/>
+	
+	<!-- Collision bitmask - by default collide with everything -->
+  <arg name="collision_bitmask" default="-1" />
 
   <!-- send the robot XML to param server -->
 	<param name="$(arg name)/robot_description" command="
@@ -20,6 +23,7 @@
 		enable_rotating_velodyne:=$(arg enable_rotating_velodyne)
 		fdm_port_in:=$(arg fdm_port_in)
 		fdm_port_out:=$(arg fdm_port_out)
+		collision_bitmask:=$(arg collision_bitmask)
 	  "
 	/>
 

--- a/models/kopterworx/urdf/kopterworx.urdf.xacro
+++ b/models/kopterworx/urdf/kopterworx.urdf.xacro
@@ -10,6 +10,10 @@
 	<xacro:property name="fdm_port_out" value="$(arg fdm_port_out)"/>
 	<xacro:property name="max_range" value="$(arg max_range)"/>
 	<xacro:property name="laser_count" value="$(arg laser_count)"/>
+
+	<!-- Collision bitmask - By default collides with everything -->
+	<xacro:arg name="collision_bitmask" default="-1" />
+	<xacro:property name="collision_bitmask" value="$(arg collision_bitmask)" />
 	
 	<gazebo>
     <plugin name="gazebo_ros_control" filename="libgazebo_ros_control.so">

--- a/models/kopterworx/urdf/kopterworx_base.urdf.xacro
+++ b/models/kopterworx/urdf/kopterworx_base.urdf.xacro
@@ -30,6 +30,10 @@
   <xacro:property name="rotor_drag_coefficient" value="8.06428e-05" />
   <xacro:property name="rolling_moment_coefficient" value="0.000001" />
 
+  <!-- Collision bitmask - By default collides with everything -->
+  <xacro:arg name="collision_bitmask" default="-1" />
+  <xacro:property name="collision_bitmask" value="$(arg collision_bitmask)" />
+
   <!-- Property Blocks -->
   <xacro:property name="body_inertia">  
     <inertia ixx="0.303755" ixy="0.0004484919" ixz="0.0010159727" iyy="0.27722" iyz="-0.001806885" izz="0.469164" />
@@ -142,6 +146,13 @@
 
   <gazebo reference="$(arg namespace)/base_link">
     <dampingFactor>0.001</dampingFactor>
+    <collision>
+      <surface>
+        <contact>
+          <collide_bitmask>${collision_bitmask}</collide_bitmask>
+        </contact>
+      </surface>
+    </collision>
   </gazebo>
 
 </robot>

--- a/models/util/multirotor_base.urdf.xacro
+++ b/models/util/multirotor_base.urdf.xacro
@@ -20,12 +20,31 @@
   <!-- Main multirotor link -->
   <xacro:macro name="multirotor_base_macro"
     params="robot_namespace mass body_width body_height mesh_file mesh_scale *origin *inertia">
+    <gazebo reference="${robot_namespace}/base_link">
+      <collision>
+        <surface>
+          <contact>
+            <collide_bitmask>${collision_bitmask}</collide_bitmask>
+          </contact>
+        </surface>
+      </collision>
+    </gazebo>
     <link name="${robot_namespace}/base_link"></link>
     <joint name="base_joint" type="fixed">
       <xacro:insert_block name="origin"/>
       <parent link="${robot_namespace}/base_link" />
       <child link="${robot_namespace}/base_link_inertia" />
     </joint>
+
+    <gazebo reference="${robot_namespace}/base_link_inertia">
+      <collision>
+        <surface>
+          <contact>
+            <collide_bitmask>${collision_bitmask}</collide_bitmask>
+          </contact>
+        </surface>
+      </collision>
+    </gazebo>
     <link name="${robot_namespace}/base_link_inertia">
       <inertial>
         <mass value="${mass}" />  <!-- [kg] -->
@@ -61,6 +80,13 @@
     </link>
 
     <gazebo reference="imu_link">
+      <collision>
+        <surface>
+          <contact>
+            <collide_bitmask>${collision_bitmask}</collide_bitmask>
+          </contact>
+        </surface>
+      </collision>
       <sensor name="imu_sensor" type="imu">
         <always_on>true</always_on>
         <update_rate>50</update_rate>
@@ -115,6 +141,15 @@
     <!-- TODO(ff): not currently set because it's not yet supported -->
     <!-- <gazebo reference="rotor_${motor_number}_joint"> <axis> <xyz>0 0 1</xyz> 
       <limit> <velocity> ${max_rot_velocity} </velocity> </limit> </axis> </gazebo> -->
+    <gazebo reference="${robot_namespace}/rotor_${motor_number}">
+      <collision>
+        <surface>
+          <contact>
+            <collide_bitmask>${collision_bitmask}</collide_bitmask>
+          </contact>
+        </surface>
+      </collision>
+    </gazebo>
     <link name="${robot_namespace}/rotor_${motor_number}">
       <inertial>
         <mass value="${mass_rotor}" /> <!-- [kg] -->
@@ -230,6 +265,15 @@
   <xacro:macro name="cam" params="namespace camera_link camera_mass parent *origin *inertia">
 
     <!-- Camera link -->
+    <gazebo reference="${namespace}/camera_box">
+      <collision>
+        <surface>
+          <contact>
+            <collide_bitmask>${collision_bitmask}</collide_bitmask>
+          </contact>
+        </surface>
+      </collision>
+    </gazebo>
     <link name="${namespace}/camera_box">
 
       <!--collision>
@@ -260,6 +304,15 @@
       <child link="${namespace}/camera_box"/>
     </joint>
 
+    <gazebo reference="${namespace}/camera">
+      <collision>
+        <surface>
+          <contact>
+            <collide_bitmask>${collision_bitmask}</collide_bitmask>
+          </contact>
+        </surface>
+      </collision>
+    </gazebo>
     <link name="${namespace}/camera"/>
 
     <joint name="camera_help" type="fixed">
@@ -347,6 +400,15 @@
             <preserveFixedJoint>true</preserveFixedJoint>
         </gazebo>
 
+        <gazebo reference="gimbal_link_1">
+          <collision>
+            <surface>
+              <contact>
+                <collide_bitmask>${collision_bitmask}</collide_bitmask>
+              </contact>
+            </surface>
+          </collision>
+        </gazebo>
         <link name="gimbal_link_1">
             <inertial>
                 <mass value="0.0001" />
@@ -366,6 +428,15 @@
             <dynamics damping="0.0" friction="0.0" />
         </joint>
 
+        <gazebo reference="gimbal_link_2">
+          <collision>
+            <surface>
+              <contact>
+                <collide_bitmask>${collision_bitmask}</collide_bitmask>
+              </contact>
+            </surface>
+          </collision>
+        </gazebo>
         <link name="gimbal_link_2">
             <inertial>
                 <mass value="0.0001" />
@@ -385,6 +456,15 @@
             <dynamics damping="0.0" friction="0.0" />
         </joint>
 
+        <gazebo reference="gimbal_link_3">
+          <collision>
+            <surface>
+              <contact>
+                <collide_bitmask>${collision_bitmask}</collide_bitmask>
+              </contact>
+            </surface>
+          </collision>
+        </gazebo>
         <link name="gimbal_link_3">
             <inertial>
                 <mass value="0.0001" />
@@ -404,6 +484,15 @@
             <dynamics damping="0.0" friction="0.0" />
         </joint>
 
+        <gazebo reference="gimbal_link_4">
+          <collision>
+            <surface>
+              <contact>
+                <collide_bitmask>${collision_bitmask}</collide_bitmask>
+              </contact>
+            </surface>
+          </collision>
+        </gazebo>
         <link name="gimbal_link_4">
             <inertial>
                 <mass value="0.0001" />
@@ -429,6 +518,15 @@
             <axis xyz="0 0 1" />
             <dynamics damping="0.0" friction="0.0" />
         </joint>
+        <gazebo reference="camera_link">
+          <collision>
+            <surface>
+              <contact>
+                <collide_bitmask>${collision_bitmask}</collide_bitmask>
+              </contact>
+            </surface>
+          </collision>
+        </gazebo>
         <link name="camera_link">
         </link>
 
@@ -439,6 +537,15 @@
         </joint>
         <gazebo reference="camera_optical_joint">
             <preserveFixedJoint>true</preserveFixedJoint>
+        </gazebo>
+        <gazebo reference="camera_optical_frame">
+          <collision>
+            <surface>
+              <contact>
+                <collide_bitmask>${collision_bitmask}</collide_bitmask>
+              </contact>
+            </surface>
+          </collision>
         </gazebo>
         <link name="camera_optical_frame">
         </link>
@@ -531,6 +638,15 @@
         <child link="${namespace}/electromagnet_bar"/>
       </joint>
 
+      <gazebo reference="${namespace}/electromagnet_bar">
+        <collision>
+          <surface>
+            <contact>
+              <collide_bitmask>${collision_bitmask}</collide_bitmask>
+            </contact>
+          </surface>
+        </collision>
+      </gazebo>
       <link name="${namespace}/electromagnet_bar">
         <inertial>
           <origin xyz="0 0 0" rpy="0 0 0" />
@@ -545,6 +661,15 @@
         </visual>
       </link>
 
+      <gazebo reference="${namespace}/electromagnet_actuator">
+        <collision>
+          <surface>
+            <contact>
+              <collide_bitmask>${collision_bitmask}</collide_bitmask>
+            </contact>
+          </surface>
+        </collision>
+      </gazebo>
       <link name="${namespace}/electromagnet_actuator">
         <inertial>
           <origin xyz="0 0 0" rpy="0 0 0" />


### PR DESCRIPTION
Add collision bitmask to all links in kopterworx simulation model. The default value is -1 which collides with everything. User can change that value through launch file arguments.